### PR TITLE
removed unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "lodash": "~2.4.1",
     "moment": "^2.7.0",
     "redis": "^0.12.1",
-    "reds": "^0.2.4",
-    "time": "^0.10.0"
+    "reds": "^0.2.4"
   },
   "devDependencies": {
     "mocha": "^1.18.2",


### PR DESCRIPTION
I was having trouble getting the time module to install on an ubuntu instance and also saw a number of issues for it on its issues page. Since it turns out that it's not even being used currently, I removed it.