### PR TITLE
Support logging to stdout in addition to Redis

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@
       _results = [];
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         job = _ref[_i];
-        _results.push(self.worker.push(new Worker(job)));
+        _results.push(self.worker.push(new Worker(job, self.options)));
       }
       return _results;
     };

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -126,7 +126,7 @@
         data: log,
         status: this.status
       };
-      if (this.options && this.options.consoleLog) {
+      if (this.options && this.options.debug) {
         console.log(log);
       }
       hash = this.prefix + ':log:' + this.job.id;

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -12,8 +12,9 @@
   noop = function() {};
 
   Worker = (function() {
-    function Worker(job) {
+    function Worker(job, options) {
       this.job = job;
+      this.options = options;
       this.client = Worker.client;
       this.prefix = Worker.prefix;
       this.initStatus();
@@ -125,6 +126,9 @@
         data: log,
         status: this.status
       };
+      if (this.options && this.options.consoleLog) {
+        console.log(log);
+      }
       hash = this.prefix + ':log:' + this.job.id;
       return this.client.multi().lpush(hash, JSON.stringify(logObj)).ltrim(hash, 0, 20).exec((function(_this) {
         return function() {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -16,7 +16,7 @@ BunnyCron =  (@options = {})->
     self.jobs = Cron.loadFile(self.options.cronFile)
     self.worker = []
     for job in self.jobs
-      self.worker.push new Worker(job)
+      self.worker.push new Worker(job, self.options)
 
   createWorker() if @options.cronFile?
 

--- a/src/worker.coffee
+++ b/src/worker.coffee
@@ -95,7 +95,7 @@ class Worker
       data: log
       status: @status
 
-    if @options && @options.consoleLog
+    if @options && @options.debug
       console.log log
 
     hash = @prefix + ':log:' + @job.id

--- a/src/worker.coffee
+++ b/src/worker.coffee
@@ -6,7 +6,7 @@ events = require('events')
 noop = ->
 
 class Worker
-  constructor: (@job) ->
+  constructor: (@job, @options) ->
     @client = Worker.client
     @prefix = Worker.prefix
     @initStatus()
@@ -94,6 +94,9 @@ class Worker
       completedAt: Date.now()
       data: log
       status: @status
+
+    if @options && @options.consoleLog
+      console.log log
 
     hash = @prefix + ':log:' + @job.id
     @client.multi().lpush(hash, JSON.stringify(logObj)).ltrim(hash, 0, 20).exec =>


### PR DESCRIPTION
I wanted to add support for the ability to send log data to standard out. I use bunnycron on a project that is running in production and I've found it's more convenient and easier for debugging for my team to be able to look through all of our logged data if it's in one log file.